### PR TITLE
DC3-67 Update comet implementation in aliases and root

### DIFF
--- a/scripts/helpers/commandUtil.ts
+++ b/scripts/helpers/commandUtil.ts
@@ -43,3 +43,19 @@ export function extractProposalId(output: string): string {
   
   throw new Error('Could not extract proposal ID from output');
 }
+
+/**
+ * Extracts implementation address from governance flow response logs
+ * @param output - The governance flow response output to search
+ * @returns string - The extracted implementation address
+ * @throws Error if implementation address cannot be found
+ */
+export function extractImplementationAddress(output: string): string {
+  // Look for "newComet": "0x..." pattern in the logs
+  const implAddressMatch = output.match(/"newComet"\s*:\s*"(0x[a-fA-F0-9]{40})"/);
+  if (implAddressMatch) {
+    return implAddressMatch[1];
+  }
+  
+  throw new Error('Could not extract implementation address from governance flow response');
+}


### PR DESCRIPTION
Extracted new implementation from logs and used to write on deployment json files in order to refresh roots with spider. This leaves us with a full automatizable code, using `yes |` with this script.